### PR TITLE
Slight tweak to help parse extremely minimal registrar information (i.e. gocl.io).

### DIFF
--- a/check_whois
+++ b/check_whois
@@ -179,8 +179,8 @@ sub grok {
             tr/A-Z/a-z/;
             $expires = $_;
         }
-        elsif (/(expiry|renewal) date:\s+(.*)/) {
-            $expires = $2;
+        elsif (/(expiry|renewal) (date|):\s+(.*)/) {
+            $expires = $3;
         }
 
 


### PR DESCRIPTION
This PR fixes the parsing of extremely minimal registrar information, like that given for gocl.io:

```
Domain : gocl.io
Status : Live
Expiry : 2014-10-04

NS 1   : ns1.p04.dynect.net
NS 2   : ns2.p04.dynect.net
NS 3   : ns3.p04.dynect.net
NS 4   : ns4.p04.dynect.net
```
